### PR TITLE
[CleanArch-01] Add dependency map, boundary backlog, and ADR-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ internal/
 - **データベース**: MongoDB v2
 - **アーキテクチャ**: DDD（ドメイン駆動設計）
 
+### Clean Architecture 移行ドキュメント（2026-02開始）
+- [依存マップ（Issue #12）](docs/clean-architecture/dependency-map.md)
+- [境界違反バックログ（Issue #13）](docs/clean-architecture/boundary-backlog.md)
+- [ADR-001 レイヤ定義・Port方針・命名規約（Issue #14）](docs/clean-architecture/adr-001-layer-port-conventions.md)
+
 ---
 
 ## 🚀 セットアップ

--- a/docs/clean-architecture/adr-001-layer-port-conventions.md
+++ b/docs/clean-architecture/adr-001-layer-port-conventions.md
@@ -1,0 +1,108 @@
+# ADR-001: レイヤ定義・Port方針・命名規約
+
+- Status: Proposed
+- Date: 2026-02-14
+- Related Issues: #11, #12, #13, #14
+
+## Context
+
+現構成は `domain / application / usecase / interface / infrastructure` だが、以下の課題がある。
+
+- `application` と `usecase` の責務が重複し、境界が曖昧
+- Domain層にDB実装依存が混入
+- エラー分類とHTTP変換規約が統一されていない
+
+## Decision
+
+### 1. ターゲットレイヤ（依存方向）
+
+依存方向は次に統一する。
+
+`Entity <- UseCase <- Interface Adapter <- Framework/DB`
+
+- `Entity` (Domain): ビジネスルール、値オブジェクト、エンティティ
+- `UseCase` (Application Business Rules): 入出力ポートを介したユースケース実行
+- `Interface Adapter`: HTTPハンドラ、Presenter、Repository Adapter
+- `Framework/DB`: Gin、MongoDBドライバ、外部APIクライアント
+
+### 2. Port方針
+
+UseCase層に入出力ポートを定義し、外側実装はAdapter層で行う。
+
+- Input Port: ハンドラから呼ばれるユースケースAPI
+- Output Port: 永続化や外部サービス呼び出しの抽象
+
+規約:
+- UseCase層は `gin` / `mongo` / `bson` をimportしない
+- Domain層は外部ライブラリ依存を持たない（標準ライブラリのみ）
+- Adapter層のみがFramework/DBの型を扱う
+
+### 3. エラー分類規約
+
+エラーは3分類とし、境界で明示的に変換する。
+
+- Domain Error: ビジネス不変条件違反（例: 無効な値）
+- UseCase Error: ユースケース実行上の業務エラー（例: 権限不足、前提未充足）
+- Infra Error: DB/ネットワーク等の技術エラー
+
+変換ルール:
+- Domain/UseCase/Infra -> AdapterでHTTPステータスへマッピング
+- 文字列判定ではなく型またはコードで判定する
+
+### 4. ディレクトリ・命名規約
+
+`internal` 配下の将来レイアウト:
+
+```text
+internal/
+  domain/
+    <context>/
+      entity.go
+      value_object.go
+      error.go
+
+  usecase/
+    <context>/
+      port_in.go
+      port_out.go
+      service.go
+      dto.go
+      error.go
+
+  adapter/
+    http/
+      handler/
+      presenter/
+    persistence/
+      mongodb/
+
+  infrastructure/
+    mongodb/
+    logger/
+```
+
+命名規約:
+- Input Port: `XXXUseCase` interface
+- Output Port: `XXXRepository` / `XXXGateway` interface
+- UseCase実装: `XXXService`
+- Adapter実装: `MongoXXXRepository`, `HTTPXXXHandler`
+
+### 5. 既存 `application` 層の扱い
+
+移行期間中は `application` を暫定層として許容するが、新規機能は `usecase` に直接実装する。
+
+- 既存 `application` は段階的に `usecase` または `adapter` へ吸収
+- 吸収完了したコンテキストから `internal/application/<context>` を削除
+
+## Consequences
+
+- 利点: 依存方向が固定され、テスト容易性と差し替え容易性が上がる
+- 欠点: 移行期間に一時的な重複実装が発生する
+- 対策: コンテキスト単位で完了させ、完了後に旧層を即時削除する
+
+## Migration Plan (Summary)
+
+1. #15 で `tag/removal` をパイロット移行しテンプレート化
+2. #16 で `idol/group/agency/event` へ水平展開
+3. #17-#18 でテスト/CI境界チェックを導入
+4. #19 でドキュメント最終更新と旧構成クローズ

--- a/docs/clean-architecture/boundary-backlog.md
+++ b/docs/clean-architecture/boundary-backlog.md
@@ -1,0 +1,44 @@
+# CleanArch 責務重複・境界違反バックログ（Issue #13）
+
+最終更新: 2026-02-14
+入力資料: `docs/clean-architecture/dependency-map.md`
+
+## 1. 目的
+
+`application` と `usecase` の責務重複、および境界違反候補を優先度付きで整理し、移行順を固定する。
+
+## 2. 優先度付きバックログ
+
+| ID | Priority | テーマ | 根拠 | 対応方針 |
+|---|---|---|---|---|
+| CA-001 | High | Domain層のMongo依存除去 | `internal/domain/removal/removal_id.go:6`, `internal/domain/tag/value_object.go:7` | ID検証/生成をインフラまたは専用ユーティリティへ移管し、`domain` は文字列規約のみ保持 |
+| CA-002 | High | Interface層のInfra依存除去 | `internal/interface/middleware/error.go:10`, `internal/interface/middleware/error.go:173` | DB固有エラー判定をAdapter層へ閉じ込め、HTTP層はアプリ共通エラーコードのみ解釈 |
+| CA-003 | High | UseCase/Application責務の二重化解消 | `internal/usecase/idol/service.go:29`, `internal/application/idol/service.go:26` | UseCaseをI/Oポート中心へ再定義し、ApplicationはUseCase実装か薄いトランザクション層へ統合 |
+| CA-004 | High | 複数Application横断依存の縮小 | `internal/usecase/removal/service.go:7` | ユースケース単位で必要ポートを定義し、`idol/group` 直参照をOutput Port化 |
+| CA-005 | Medium | バリデーション責務の境界統一 | `internal/interface/handlers/idol_handler.go:127`, `internal/usecase/idol/query.go:79` | 入力バリデーション責務を「Adapterで形式」「UseCaseで業務」に分離し規約化 |
+| CA-006 | Medium | 検索Query/ページネーション重複排除 | `internal/usecase/idol/query.go:55`, `internal/usecase/event/query.go:46`, `internal/usecase/tag/service.go:57` | 共通Pagination/Sortポリシーを `usecase/shared` に切り出す |
+| CA-007 | Medium | エラーマッピングの一貫化 | `internal/interface/handlers/idol_handler.go:63`, `internal/interface/handlers/event_handler.go:43` | `middleware.WriteError` に統一し、HTTPステータス判定ルールを1箇所化 |
+| CA-008 | Low | UseCase DTOのHTTPタグ依存解消 | `internal/usecase/event/command.go:5` | `json`/`binding` タグ付きDTOをinterface層へ移し、usecase層は純粋コマンド型に変更 |
+
+## 3. 重複責務の具体例（抜粋）
+
+| ユースケース層 | アプリケーション層 | 重複/曖昧点 |
+|---|---|---|
+| `CreateIdol` (`internal/usecase/idol/service.go:29`) | `CreateIdol` (`internal/application/idol/service.go:26`) | 両層が同じユースケース名で存在し責務境界が読みにくい |
+| `UpdateIdol` (`internal/usecase/idol/service.go:79`) | `UpdateIdol` (`internal/application/idol/service.go:92`) | UseCaseがInput変換のみ、実処理はApplicationに集中 |
+| `SearchEvents` (`internal/usecase/event/service.go:57`) | `SearchEvents` (`internal/application/event/service.go:113`) | 検索条件/ページング責務が2層に分散 |
+| `CreateRemovalRequest` (`internal/usecase/removal/service.go:29`) | `CreateRemovalRequest` (`internal/application/removal/service.go:23`) | 存在確認・状態遷移・永続化が複層にまたがる |
+
+## 4. 推奨実行順（#13 内）
+
+1. `CA-001` と `CA-002` を先行（境界違反の直接解消）
+2. `CA-003` と `CA-004` で UseCase/Application の責務再配置
+3. `CA-005` から `CA-007` で入力・エラー・共通処理を統一
+4. `CA-008` を最後に実施（影響範囲が広いが緊急度は低い）
+
+## 5. #14 への接続ポイント
+
+ADRで先に合意すべき項目:
+- UseCaseを唯一のアプリケーション境界にするか
+- Application層を残す場合の責務（トランザクション/オーケストレーション限定など）
+- エラー型の正規仕様（Domain/UseCase/Infraの分類と変換地点）

--- a/docs/clean-architecture/dependency-map.md
+++ b/docs/clean-architecture/dependency-map.md
@@ -1,0 +1,100 @@
+# CleanArch 依存マップ（Issue #12）
+
+最終更新: 2026-02-14
+対象リポジトリ: `kuro48/idol-database`
+
+## 1. 目的と範囲
+
+クリーンアーキテクチャ移行（#11）の前提として、`cmd/api` と `internal/**` の依存関係を可視化する。
+
+- 対象: `cmd/api`, `internal/config`, `internal/domain`, `internal/application`, `internal/usecase`, `internal/interface`, `internal/infrastructure`
+- 手法: `go list` による import 解析
+
+## 2. 依存抽出コマンド
+
+```bash
+go list -f '{{.ImportPath}}|{{range .Imports}}{{.}} {{end}}' ./cmd/... ./internal/...
+```
+
+## 3. 層間依存サマリ
+
+```mermaid
+graph LR
+  CMD["cmd"] --> APP["application"]
+  CMD --> UC["usecase"]
+  CMD --> IF["interface"]
+  CMD --> INF["infrastructure"]
+  CMD --> CFG["config"]
+  APP --> DOM["domain"]
+  UC --> APP
+  UC --> DOM
+  IF --> UC
+  IF --> IF
+  INF --> DOM
+```
+
+| 依存方向 | 件数 |
+|---|---:|
+| `application -> domain` | 6 |
+| `usecase -> application` | 9 |
+| `usecase -> domain` | 6 |
+| `interface -> usecase` | 6 |
+| `interface -> interface` | 1 |
+| `infrastructure -> domain` | 6 |
+| `cmd -> application` | 6 |
+| `cmd -> usecase` | 6 |
+| `cmd -> interface` | 2 |
+| `cmd -> infrastructure` | 2 |
+| `cmd -> config` | 1 |
+
+## 4. 主要パッケージ依存一覧（内部依存のみ）
+
+| パッケージ | 依存先（内部） |
+|---|---|
+| `cmd/api` | `docs`, `internal/application/*`, `internal/usecase/*`, `internal/interface/{handlers,middleware}`, `internal/infrastructure/{database,persistence/mongodb}`, `internal/config` |
+| `internal/application/*` | 各 `internal/domain/*` |
+| `internal/usecase/agency` | `internal/application/agency`, `internal/domain/agency` |
+| `internal/usecase/event` | `internal/application/event`, `internal/domain/event` |
+| `internal/usecase/group` | `internal/application/group`, `internal/domain/group` |
+| `internal/usecase/idol` | `internal/application/{idol,agency}`, `internal/domain/idol` |
+| `internal/usecase/removal` | `internal/application/{removal,idol,group}`, `internal/domain/removal` |
+| `internal/usecase/tag` | `internal/application/tag`, `internal/domain/tag` |
+| `internal/interface/handlers` | `internal/interface/middleware`, `internal/usecase/*` |
+| `internal/infrastructure/persistence/mongodb` | `internal/domain/*` |
+
+## 5. 許容依存（現時点）
+
+- `interface -> usecase`
+- `usecase -> domain`
+- `application -> domain`
+- `infrastructure -> domain`
+- `cmd -> *`（Composition Rootとして許容）
+
+## 6. 境界違反候補（初版）
+
+1. Domain層がMongoDBドライバに依存
+- `internal/domain/removal/removal_id.go:6`
+- `internal/domain/tag/value_object.go:7`
+- 影響: `domain` が特定DB実装（`bson.ObjectID`）を知っている。
+
+2. Interface middlewareがMongoDB固有エラー型に依存
+- `internal/interface/middleware/error.go:10`
+- 影響: HTTP層で永続化実装詳細（`mongo`）に結合。
+
+3. UseCase層がApplication層へ直接依存
+- 例: `internal/usecase/idol/service.go:12`
+- 影響: 目標依存方向（`Entity <- UseCase <- Interface Adapter`）へ移行する際の段差。
+- 補足: 現構成では移行途中設計としては成立しており、直ちに不正とは断定しない。
+
+4. UseCase層が複数Applicationサービスを横断参照
+- 例: `internal/usecase/removal/service.go:7`
+- 影響: ユースケース境界の肥大化、責務重複の温床。
+
+5. `cmd/api` が `application` と `usecase` の両方を同時配線
+- `cmd/api/main.go:26`
+- 影響: 依存注入方針が不統一で、ポート境界の見通しが悪化。
+
+## 7. 次アクション（#13 接続）
+
+- #13で上記候補を `High/Medium/Low` に優先度付けし、責務重複バックログへ昇格する。
+- 特に `Domain層のMongo依存` は最優先候補として切り出す。


### PR DESCRIPTION
## Summary
- add dependency map document for Issue #12
- add prioritized boundary backlog for Issue #13
- add ADR-001 for layer/port/naming conventions for Issue #14
- add README links to the new clean-architecture docs

## Changed Files
- docs/clean-architecture/dependency-map.md
- docs/clean-architecture/boundary-backlog.md
- docs/clean-architecture/adr-001-layer-port-conventions.md
- README.md

## Related Issues
- #11
- #12
- #13
- #14

## Verification
- go test ./... (fails due to pre-existing build/test issues unrelated to this docs-only PR)
  - internal/usecase/idol/service.go: SearchCriteria field mismatch
  - internal/infrastructure/persistence/mongodb/idol_repository.go: type mismatch
  - internal/config/config_test.go: env-dependent failure
