### PR TITLE
fix: require ADMIN_API_KEY in release mode (#44)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,14 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// 本番モードでは AdminAPIKey を必須とする
+	if c.GinMode == "release" && c.AdminAPIKey == "" {
+		return &ValidationError{
+			Field:   "ADMIN_API_KEY",
+			Message: "本番環境では ADMIN_API_KEY の設定が必須です",
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ func TestLoad(t *testing.T) {
 		t.Setenv("MONGODB_DATABASE", "test_database")
 		t.Setenv("SERVER_PORT", "9000")
 		t.Setenv("GIN_MODE", "release")
+		t.Setenv("ADMIN_API_KEY", "test-admin-key")
 
 		cfg, err := Load()
 
@@ -77,6 +78,36 @@ func TestLoad(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
+	})
+
+	t.Run("release mode without ADMIN_API_KEY returns error", func(t *testing.T) {
+		t.Setenv("MONGODB_URI", "mongodb://test:test@localhost:27017")
+		t.Setenv("MONGODB_DATABASE", "test_database")
+		t.Setenv("SERVER_PORT", "8081")
+		t.Setenv("GIN_MODE", "release")
+		t.Setenv("ADMIN_API_KEY", "")
+
+		cfg, err := Load()
+
+		assert.Error(t, err)
+		assert.Nil(t, cfg)
+		var valErr *ValidationError
+		assert.ErrorAs(t, err, &valErr)
+		assert.Equal(t, "ADMIN_API_KEY", valErr.Field)
+	})
+
+	t.Run("release mode with ADMIN_API_KEY succeeds", func(t *testing.T) {
+		t.Setenv("MONGODB_URI", "mongodb://test:test@localhost:27017")
+		t.Setenv("MONGODB_DATABASE", "test_database")
+		t.Setenv("SERVER_PORT", "8081")
+		t.Setenv("GIN_MODE", "release")
+		t.Setenv("ADMIN_API_KEY", "secret-admin-key")
+
+		cfg, err := Load()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg)
+		assert.Equal(t, "secret-admin-key", cfg.AdminAPIKey)
 	})
 }
 


### PR DESCRIPTION
## Summary
- `config.Validate()` に GIN_MODE=release かつ ADMIN_API_KEY 未設定の場合の起動拒否を追加
- APIキーなしで本番サーバーが起動してしまうセキュリティリスクを解消

## Test plan
- [ ] `go test ./internal/config/...` が全件パス
- [ ] `GIN_MODE=release` + `ADMIN_API_KEY` 未設定でサーバーが起動エラーになることを確認

Closes #44