### PR TITLE
fix: treat empty birthdate string as nil (#59)

### DIFF
--- a/internal/application/idol/service.go
+++ b/internal/application/idol/service.go
@@ -36,7 +36,7 @@ func (s *ApplicationService) CreateIdol(ctx context.Context, input CreateInput) 
 	}
 
 	var birthdate *idol.Birthdate
-	if input.Birthdate != nil {
+	if input.Birthdate != nil && *input.Birthdate != "" {
 		bd, err := idol.NewBirthdateFromString(*input.Birthdate)
 		if err != nil {
 			return nil, fmt.Errorf("生年月日の生成エラー: %w", err)
@@ -121,12 +121,14 @@ func (s *ApplicationService) UpdateIdol(ctx context.Context, input UpdateInput) 
 		}
 	}
 
-	if input.Birthdate != nil {
+	if input.Birthdate != nil && *input.Birthdate != "" {
 		bd, err := idol.NewBirthdateFromString(*input.Birthdate)
 		if err != nil {
 			return fmt.Errorf("生年月日の生成エラー: %w", err)
 		}
 		existingIdol.UpdateBirthdate(&bd)
+	} else if input.Birthdate != nil && *input.Birthdate == "" {
+		existingIdol.UpdateBirthdate(nil)
 	}
 
 	if input.AgencyID != nil {

--- a/internal/interface/handlers/idol_handler.go
+++ b/internal/interface/handlers/idol_handler.go
@@ -52,9 +52,13 @@ func (h *IdolHandler) CreateIdol(c *gin.Context) {
 		return
 	}
 
+	var birthdate *string
+	if req.Birthdate != "" {
+		birthdate = &req.Birthdate
+	}
 	cmd := idol.CreateIdolCommand{
 		Name:      req.Name,
-		Birthdate: &req.Birthdate,
+		Birthdate: birthdate,
 		AgencyID:  req.AgencyID,
 	}
 


### PR DESCRIPTION
## Summary
- `birthdate` 未指定時に空文字ポインタが渡りパースエラーになる問題を修正
- handler で空文字を nil に変換してからコマンドへ渡す
- application service でも `*input.Birthdate != ""` ガードを追加
- UPDATE 時に空文字を渡すと birthdate を nil クリアする動作を追加

## Test plan
- [ ] `birthdate` なしでアイドル作成が成功する
- [ ] `birthdate` ありでアイドル作成が成功する
- [ ] UPDATE で `birthdate: ""` を送ると birthdate がクリアされる

Closes #59