### PR TITLE
fix: エラーレスポンスを全ハンドラーで統一 (#64)

### DIFF
--- a/internal/interface/handlers/idol_handler.go
+++ b/internal/interface/handlers/idol_handler.go
@@ -60,7 +60,7 @@ func (h *IdolHandler) CreateIdol(c *gin.Context) {
 
 	dto, err := h.usecase.CreateIdol(middleware.AuditContextFor(c), cmd)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, middleware.NewInternalError("アイドルの作成に失敗しました"))
+		middleware.WriteError(c, err, middleware.ErrorContext{Resource: "アイドル", Message: "アイドルの作成に失敗しました"})
 		return
 	}
 
@@ -141,7 +141,7 @@ func (h *IdolHandler) ListIdols(c *gin.Context) {
 	// 検索実行
 	result, err := h.usecase.SearchIdols(c.Request.Context(), query)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, middleware.NewInternalError("検索に失敗しました"))
+		middleware.WriteError(c, err, middleware.ErrorContext{Resource: "アイドル", Message: "検索に失敗しました"})
 		return
 	}
 
@@ -182,7 +182,7 @@ func (h *IdolHandler) UpdateIdol(c *gin.Context) {
 
 	err := h.usecase.UpdateIdol(middleware.AuditContextFor(c), cmd)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, middleware.NewInternalError("アイドルの更新に失敗しました"))
+		middleware.WriteError(c, err, middleware.ErrorContext{Resource: "アイドル", Message: "アイドルの更新に失敗しました"})
 		return
 	}
 
@@ -211,7 +211,7 @@ func (h *IdolHandler) DeleteIdol(c *gin.Context) {
 
 	err := h.usecase.DeleteIdol(c.Request.Context(), cmd)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, middleware.NewInternalError("アイドルの削除に失敗しました"))
+		middleware.WriteError(c, err, middleware.ErrorContext{Resource: "アイドル", Message: "アイドルの削除に失敗しました"})
 		return
 	}
 
@@ -345,7 +345,7 @@ func (h *IdolHandler) BulkCreateIdols(c *gin.Context) {
 
 	result, err := h.usecase.BulkCreateIdols(middleware.AuditContextFor(c), cmds)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, middleware.NewInternalError("バルク作成処理中にエラーが発生しました"))
+		middleware.WriteError(c, err, middleware.ErrorContext{Resource: "アイドル", Message: "バルク作成処理中にエラーが発生しました"})
 		return
 	}
 


### PR DESCRIPTION
## Summary
- `idol_handler.go` の全エラーハンドラーを `middleware.WriteError()` パターンに統一
- 対象: `ListIdols`, `UpdateIdol`, `DeleteIdol`, `BulkCreateIdols`
- エラー種別に応じて 404/409/400/500 を自動判定する仕組みを活用

Closes #64

## Test plan
- [ ] `go vet ./...` 通過確認
- [ ] CI Build & Test 通過確認