### PR TITLE
fix: MongoDB ObjectID変換エラーを全箇所で適切に処理 (#51)

### DIFF
--- a/internal/infrastructure/persistence/mongodb/group_repository.go
+++ b/internal/infrastructure/persistence/mongodb/group_repository.go
@@ -47,7 +47,10 @@ func (r *GroupRepository) FindAll(ctx context.Context) ([]*group.Group, error) {
 
 // Update implements group.Repository.
 func (r *GroupRepository) Update(ctx context.Context, g *group.Group) error {
-	doc := toGroupDocument(g)
+	doc, err := toGroupDocument(g)
+	if err != nil {
+		return fmt.Errorf("ドキュメント変換エラー: %w", err)
+	}
 	doc.UpdatedAt = time.Now()
 	doc.UpdatedBy = audit.ActorFrom(ctx)
 
@@ -93,8 +96,11 @@ type groupDocument struct {
 	DeletedBy     string        `bson:"deleted_by,omitempty"`
 }
 
-func toGroupDocument(g *group.Group) *groupDocument {
-	objectID, _ := bson.ObjectIDFromHex(g.ID().Value())
+func toGroupDocument(g *group.Group) (*groupDocument, error) {
+	objectID, err := bson.ObjectIDFromHex(g.ID().Value())
+	if err != nil && g.ID().Value() != "" {
+		return nil, fmt.Errorf("無効なグループID %q: %w", g.ID().Value(), err)
+	}
 
 	var formationDate *time.Time
 	if g.FormationDate() != nil {
@@ -115,7 +121,7 @@ func toGroupDocument(g *group.Group) *groupDocument {
 		DisbandDate:   disbandDate,
 		CreatedAt:     g.CreatedAt(),
 		UpdatedAt:     g.UpdatedAt(),
-	}
+	}, nil
 }
 
 func toGroupDomain(doc *groupDocument) (*group.Group, error) {
@@ -155,7 +161,10 @@ func toGroupDomain(doc *groupDocument) (*group.Group, error) {
 }
 
 func (r *GroupRepository) Save(ctx context.Context, g *group.Group) error {
-	doc := toGroupDocument(g)
+	doc, err := toGroupDocument(g)
+	if err != nil {
+		return fmt.Errorf("ドキュメント変換エラー: %w", err)
+	}
 
 	// 新規作成の場合はIDを生成
 	if doc.ID.IsZero() {
@@ -174,9 +183,8 @@ func (r *GroupRepository) Save(ctx context.Context, g *group.Group) error {
 		g.SetID(id)
 	}
 
-	_, err := r.collection.InsertOne(ctx, doc)
-	if err != nil {
-		return fmt.Errorf("グループの保存エラー: %w", err)
+	if _, insertErr := r.collection.InsertOne(ctx, doc); insertErr != nil {
+		return fmt.Errorf("グループの保存エラー: %w", insertErr)
 	}
 
 	return nil

--- a/internal/infrastructure/persistence/mongodb/idol_repository.go
+++ b/internal/infrastructure/persistence/mongodb/idol_repository.go
@@ -56,9 +56,12 @@ type socialLinksDocument struct {
 }
 
 // toDocument はドメインモデルをMongoDBドキュメントに変換する
-func toIdolDocument(i *idol.Idol) *idolDocument {
+func toIdolDocument(i *idol.Idol) (*idolDocument, error) {
 	// IDの文字列をObjectIDに変換
-	objectID, _ := bson.ObjectIDFromHex(i.ID().Value())
+	objectID, err := bson.ObjectIDFromHex(i.ID().Value())
+	if err != nil && i.ID().Value() != "" {
+		return nil, fmt.Errorf("無効なアイドルID %q: %w", i.ID().Value(), err)
+	}
 
 	var socialLinksDoc *socialLinksDocument
 	if i.SocialLinks() != nil {
@@ -91,7 +94,7 @@ func toIdolDocument(i *idol.Idol) *idolDocument {
 		TagIDs:      i.TagIDs(),
 		CreatedAt:   i.CreatedAt(),
 		UpdatedAt:   i.UpdatedAt(),
-	}
+	}, nil
 }
 
 // toSocialLinksDocument はSocialLinksをドキュメントに変換する
@@ -184,7 +187,10 @@ func toSocialLinksDomain(doc *socialLinksDocument) *idol.SocialLinks {
 
 // Save は新しいアイドルを保存する
 func (r *IdolRepository) Save(ctx context.Context, i *idol.Idol) error {
-	doc := toIdolDocument(i)
+	doc, err := toIdolDocument(i)
+	if err != nil {
+		return fmt.Errorf("ドキュメント変換エラー: %w", err)
+	}
 
 	// 新規作成の場合はIDを生成
 	if doc.ID.IsZero() {
@@ -202,9 +208,8 @@ func (r *IdolRepository) Save(ctx context.Context, i *idol.Idol) error {
 		i.SetID(newID)
 	}
 
-	_, err := r.collection.InsertOne(ctx, doc)
-	if err != nil {
-		return fmt.Errorf("アイドルの保存エラー: %w", err)
+	if _, insertErr := r.collection.InsertOne(ctx, doc); insertErr != nil {
+		return fmt.Errorf("アイドルの保存エラー: %w", insertErr)
 	}
 
 	return nil
@@ -261,7 +266,10 @@ func (r *IdolRepository) Update(ctx context.Context, i *idol.Idol) error {
 		return fmt.Errorf("無効なID形式: %w", err)
 	}
 
-	doc := toIdolDocument(i)
+	doc, err := toIdolDocument(i)
+	if err != nil {
+		return fmt.Errorf("ドキュメント変換エラー: %w", err)
+	}
 	doc.UpdatedAt = time.Now()
 
 	setFields := bson.M{

--- a/internal/infrastructure/persistence/mongodb/removal_repository.go
+++ b/internal/infrastructure/persistence/mongodb/removal_repository.go
@@ -39,11 +39,15 @@ type removalDocument struct {
 }
 
 // toRemovalDocument はドメインモデルをMongoDBドキュメントに変換する
-func toRemovalDocument(r *removal.RemovalRequest) *removalDocument {
+func toRemovalDocument(r *removal.RemovalRequest) (*removalDocument, error) {
 	// IDの文字列をObjectIDに変換（空の場合はゼロ値）
 	var objectID bson.ObjectID
 	if r.ID().Value() != "" {
-		objectID, _ = bson.ObjectIDFromHex(r.ID().Value())
+		var err error
+		objectID, err = bson.ObjectIDFromHex(r.ID().Value())
+		if err != nil {
+			return nil, fmt.Errorf("無効な削除申請ID %q: %w", r.ID().Value(), err)
+		}
 	}
 
 	return &removalDocument{
@@ -58,7 +62,7 @@ func toRemovalDocument(r *removal.RemovalRequest) *removalDocument {
 		Status:      string(r.Status()),
 		CreatedAt:   r.CreatedAt(),
 		UpdatedAt:   r.UpdatedAt(),
-	}
+	}, nil
 }
 
 // toRemovalDomain はMongoDBドキュメントをドメインモデルに変換する
@@ -120,7 +124,10 @@ func toRemovalDomain(doc *removalDocument) (*removal.RemovalRequest, error) {
 
 // Save は新しい削除申請を保存する
 func (r *RemovalRepository) Save(ctx context.Context, request *removal.RemovalRequest) error {
-	doc := toRemovalDocument(request)
+	doc, err := toRemovalDocument(request)
+	if err != nil {
+		return fmt.Errorf("ドキュメント変換エラー: %w", err)
+	}
 
 	// 新規作成の場合はIDを生成
 	if doc.ID.IsZero() {
@@ -135,9 +142,8 @@ func (r *RemovalRepository) Save(ctx context.Context, request *removal.RemovalRe
 		request.SetID(newID)
 	}
 
-	_, err := r.collection.InsertOne(ctx, doc)
-	if err != nil {
-		return fmt.Errorf("削除申請の保存エラー: %w", err)
+	if _, insertErr := r.collection.InsertOne(ctx, doc); insertErr != nil {
+		return fmt.Errorf("削除申請の保存エラー: %w", insertErr)
 	}
 
 	return nil
@@ -219,7 +225,10 @@ func (r *RemovalRepository) Update(ctx context.Context, request *removal.Removal
 		return fmt.Errorf("無効なID形式: %w", err)
 	}
 
-	doc := toRemovalDocument(request)
+	doc, err2 := toRemovalDocument(request)
+	if err2 != nil {
+		return fmt.Errorf("ドキュメント変換エラー: %w", err2)
+	}
 	doc.UpdatedAt = time.Now()
 
 	updateDoc := bson.M{


### PR DESCRIPTION
## Summary
- `idol_repository.go`, `group_repository.go`, `removal_repository.go` の `toXxxDocument()` 関数で `bson.ObjectIDFromHex()` のエラーを無視していた問題を修正
- 全ての変換関数を `(*Doc, error)` を返すシグネチャに変更

## Changes
- `toIdolDocument()`: `(*idolDocument, error)` を返すよう変更
- `toGroupDocument()`: `(*groupDocument, error)` を返すよう変更
- `toRemovalDocument()`: `(*removalDocument, error)` を返すよう変更
- Save/Update の各呼び出し箇所でエラーを処理

Closes #51

## Test plan
- [ ] `go build ./...` 通過確認
- [ ] CI 通過確認
- [ ] 不正な ID 形式を渡した場合に適切なエラーが返ること