### PR TITLE
fix: release readiness docs and API contract alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ internal/
 - **言語**: Go 1.24+
 - **フレームワーク**: Gin
 - **データベース**: MongoDB (go.mongodb.org/mongo-driver/v2)
-- **ドキュメント**: Swagger UI (`/swagger/index.html`)
+- **ドキュメント**: Swagger UI (`/swagger/index.html`, `GIN_MODE=debug/test` のみ)
 
 ## セットアップ
 
@@ -58,21 +58,21 @@ MONGODB_URI=mongodb://admin:password@localhost:27017/?authSource=admin
 MONGODB_DATABASE=idol_database
 SERVER_PORT=8081
 GIN_MODE=debug
-API_KEY=your-write-api-key
+WRITE_API_KEY=your-write-api-key
 ADMIN_API_KEY=your-admin-api-key
 ```
 
 ## API エンドポイント
 
-Swagger UI: `http://localhost:8081/swagger/index.html`
+Swagger UI: `http://localhost:8081/swagger/index.html` (`GIN_MODE=debug/test` のみ)
 
 ### 認証
 
 | スコープ | ヘッダー | 用途 |
 |---------|---------|------|
 | 読み取り | なし | GET 系エンドポイント |
-| 書き込み | `X-API-Key: <API_KEY>` | 作成・更新・削除 |
-| 管理者 | `X-API-Key: <ADMIN_API_KEY>` | 管理エンドポイント |
+| 書き込み | `Authorization: Bearer <WRITE_API_KEY>` | 作成・更新・削除 |
+| 管理者 | `Authorization: Bearer <ADMIN_API_KEY>` | 管理エンドポイント |
 
 ### ヘルスチェック
 
@@ -87,11 +87,15 @@ GET /health/ready
 ```
 GET    /api/v1/idols                  # 検索・一覧（ページネーション付き）
 GET    /api/v1/idols/:id              # 詳細
+GET    /api/v1/idols/:id/external-ids # 外部IDマッピング取得
 POST   /api/v1/idols                  # 作成（write 権限）
 PUT    /api/v1/idols/:id              # 更新（write 権限）
 DELETE /api/v1/idols/:id              # 削除（write 権限）
 PUT    /api/v1/idols/:id/social-links # SNS リンク更新（write 権限）
+PUT    /api/v1/idols/:id/external-ids # 外部IDマッピング更新（write 権限）
 POST   /api/v1/idols/bulk             # 一括作成（write 権限）
+PUT    /api/v1/idols/:id/restore      # 復元（admin）
+GET    /api/v1/idols/:id/duplicate-candidates # 重複候補取得（admin）
 ```
 
 アイドルは `name`・`aliases`（別名/旧名）・`birthdate`・`agency_id`・`tag_ids`・`social_links`・`external_ids` を持つ。別名でも検索可能。
@@ -154,7 +158,6 @@ PUT  /api/v1/removal-requests/:id    # ステータス更新（admin）
 ```
 POST   /api/v1/admin/webhooks                      # サブスクリプション作成（admin）
 GET    /api/v1/admin/webhooks                      # 一覧（admin）
-GET    /api/v1/admin/webhooks/:id                  # 詳細（admin）
 DELETE /api/v1/admin/webhooks/:id                  # 削除（admin）
 POST   /api/v1/webhooks/receive/:subscription_id   # Webhook 受信
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,8 +5,8 @@
 ### ローカル開発
 
 ```bash
-cp .env.example .env
-# .env を編集して接続情報を設定
+cp .env.example .env.local
+# .env.local を編集して接続情報を設定
 
 go run cmd/api/main.go
 # → http://localhost:8081
@@ -34,23 +34,27 @@ docker build -t idol-api:$(git rev-parse --short HEAD) .
 # 2. 環境変数を設定（Secrets 管理推奨）
 export MONGODB_URI="mongodb+srv://..."
 export MONGODB_DATABASE="idol_database"
-export SERVER_PORT="8080"
+export SERVER_PORT="8081"
 export GIN_MODE="release"
 export CORS_ALLOWED_ORIGINS="https://your-frontend.example.com"
+export WRITE_API_KEY="$(openssl rand -hex 32)"
 export ADMIN_API_KEY="$(openssl rand -hex 32)"
 
 # 3. コンテナ起動
 docker run -d \
   --name idol-api \
-  -p 8080:8080 \
+  -p 8081:8081 \
   -e MONGODB_URI \
   -e MONGODB_DATABASE \
   -e SERVER_PORT \
   -e GIN_MODE \
   -e CORS_ALLOWED_ORIGINS \
+  -e WRITE_API_KEY \
   -e ADMIN_API_KEY \
   idol-api:$(git rev-parse --short HEAD)
 ```
+
+`GIN_MODE=release` では Swagger UI は無効です。API 疎通確認は `/health/live` と `/health/ready` を使用してください。
 
 ## CI/CD パイプライン
 
@@ -62,10 +66,42 @@ docker run -d \
 | boundary-check | push/PR | レイヤ依存方向違反チェック |
 | docker-build | push/PR | Docker イメージビルド確認 |
 
+`.github/workflows/docker-publish.yml` により、`main` への push と `v*.*.*` タグ push で GHCR にイメージを publish します。
+
+## 現在のリリースフロー
+
+現時点では、CI/GHCR 連携 + 手動デプロイを前提とします。
+
+1. `main` にリリース対象をマージする
+2. GitHub Actions の CI と Docker publish が成功していることを確認する
+3. 正式リリース時は semver 形式のタグを付与する
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+4. デプロイ先で対象イメージを pull する
+
+```bash
+docker pull ghcr.io/kuro48/idol-database:v0.1.0
+```
+
+5. 旧コンテナを停止し、新イメージで起動する
+6. `/health/live` と `/health/ready` で疎通確認する
+
+ブランチ push 時のイメージは検証用、semver タグ付きイメージは正式リリース用として扱います。
+
 ## ヘルスチェック
 
 ```bash
 curl http://localhost:8081/health
+# → {"status":"ok","message":"Idol API is running with DDD architecture"}
+
+curl http://localhost:8081/health/live
+# → {"status":"ok"}
+
+curl http://localhost:8081/health/ready
 # → {"status":"ok"}
 ```
 
@@ -73,11 +109,11 @@ curl http://localhost:8081/health
 
 ```bash
 # 前バージョンのイメージタグを確認
-docker images idol-api
+docker images ghcr.io/kuro48/idol-database
 
 # 旧バージョンを起動
 docker stop idol-api
-docker run -d --name idol-api <旧タグのイメージ> ...
+docker run -d --name idol-api ghcr.io/kuro48/idol-database:<旧タグ> ...
 ```
 
 ## リリースチェックリスト
@@ -85,16 +121,17 @@ docker run -d --name idol-api <旧タグのイメージ> ...
 - [ ] `go test ./...` がパス
 - [ ] `go vet ./...` がパス
 - [ ] CI の全ジョブがグリーン
-- [ ] `.env` の `GIN_MODE=release` を確認
+- [ ] 本番環境変数の `GIN_MODE=release` を確認
+- [ ] `WRITE_API_KEY` が本番用の値か確認
 - [ ] `ADMIN_API_KEY` が本番用の値か確認
 - [ ] `CORS_ALLOWED_ORIGINS` が本番フロントエンドURLか確認
 - [ ] MongoDB接続先が本番DBか確認
-- [ ] ヘルスチェック `/health` が正常応答
-- [ ] Swagger UI `/swagger/index.html` が正常表示
+- [ ] ヘルスチェック `/health/live` と `/health/ready` が正常応答
+- [ ] `GIN_MODE=release` 時に Swagger UI が公開されていないことを確認
 
 ## 障害時対応
 
 1. ログ確認: `docker logs idol-api --tail 100`
-2. ヘルスチェック: `curl /health`
+2. ヘルスチェック: `curl /health/live` と `curl /health/ready`
 3. 問題が解決しない場合: ロールバック実施
 4. MongoDB 接続エラーの場合: `MONGODB_URI` を確認

--- a/docs/docker-guide.md
+++ b/docs/docker-guide.md
@@ -2,7 +2,7 @@
 
 このプロジェクトでは、ローカルDockerのMongoDBとMongoDB Atlas（クラウド）の両方を使い分けることができます。
 
-## 📋 環境の種類
+## 環境の種類
 
 ### 1. **ローカルDocker MongoDB**
 - 開発・テスト用
@@ -18,9 +18,9 @@
 
 ---
 
-## 🚀 使い方
+## 使い方
 
-### **ローカルDocker MongoDBを使う場合**
+### ローカルDocker MongoDBを使う場合
 
 #### ステップ1: 環境を切り替え
 ```bash
@@ -31,10 +31,10 @@ bash scripts/use-local.sh
 #### ステップ2: MongoDBコンテナを起動
 ```bash
 # MongoDBコンテナを起動
-docker-compose up -d
+docker compose up -d
 
 # 起動確認
-docker-compose ps
+docker compose ps
 ```
 
 #### ステップ3: APIサーバーを起動
@@ -46,23 +46,29 @@ go run cmd/api/main.go
 #### ステップ4: 動作確認
 ```bash
 # ヘルスチェック
-curl http://localhost:8081/
+curl http://localhost:8081/health
 
-# 期待される出力: {"message":"Hello World"}
+# 期待される出力: {"status":"ok","message":"Idol API is running with DDD architecture"}
+
+# 依存先も含めた確認
+curl http://localhost:8081/health/ready
+
+# 開発モード時のみ Swagger UI を確認可能
+open http://localhost:8081/swagger/index.html
 ```
 
 #### ステップ5: 使用後の停止
 ```bash
 # MongoDBコンテナを停止
-docker-compose down
+docker compose down
 
 # データも削除する場合（注意！）
-docker-compose down -v
+docker compose down -v
 ```
 
 ---
 
-### **MongoDB Atlasを使う場合**
+### MongoDB Atlasを使う場合
 
 #### ステップ1: 環境を切り替え
 ```bash
@@ -79,14 +85,17 @@ go run cmd/api/main.go
 #### ステップ3: 動作確認
 ```bash
 # ヘルスチェック
-curl http://localhost:8081/
+curl http://localhost:8081/health
 
-# 期待される出力: {"message":"Hello World"}
+# 期待される出力: {"status":"ok","message":"Idol API is running with DDD architecture"}
+
+# 依存先も含めた確認
+curl http://localhost:8081/health/ready
 ```
 
 ---
 
-## 📁 ファイル構成
+## ファイル構成
 
 ```
 idol-api/
@@ -95,8 +104,7 @@ idol-api/
 ├── .env.atlas           # MongoDB Atlas用の設定
 ├── .env.example         # サンプル設定ファイル
 ├── docker-compose.yml   # ローカルMongoDB用のDocker設定
-├── .docker/
-│   └── Dockerfile       # MongoDBコンテナの設定
+├── Dockerfile           # API コンテナの設定
 └── scripts/
     ├── use-local.sh     # ローカル環境切り替えスクリプト
     └── use-atlas.sh     # Atlas環境切り替えスクリプト
@@ -104,14 +112,16 @@ idol-api/
 
 ---
 
-## 🔧 環境変数の詳細
+## 環境変数の詳細
 
 ### **.env.local（ローカルDocker用）**
 ```bash
-MONGODB_URI=mongodb://admin:password@localhost:27017
+MONGODB_URI=mongodb://admin:password@localhost:27017/?authSource=admin
 MONGODB_DATABASE=idol_database
 SERVER_PORT=8081
 GIN_MODE=debug
+WRITE_API_KEY=your-write-api-key
+ADMIN_API_KEY=your-admin-api-key
 ```
 
 ### **.env.atlas（MongoDB Atlas用）**
@@ -120,17 +130,19 @@ MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/
 MONGODB_DATABASE=idol_database
 SERVER_PORT=8081
 GIN_MODE=debug
+WRITE_API_KEY=your-write-api-key
+ADMIN_API_KEY=your-admin-api-key
 ```
 
 ---
 
-## 💡 よくある使い方
+## よくある使い方
 
 ### **パターン1: 通常の開発**
 ```bash
 # ローカルDockerで開発
 bash scripts/use-local.sh
-docker-compose up -d
+docker compose up -d
 go run cmd/api/main.go
 ```
 
@@ -144,27 +156,27 @@ go run cmd/api/main.go
 ### **パターン3: 環境切り替え**
 ```bash
 # ローカル → Atlas
-docker-compose down           # ローカルMongoDB停止
+docker compose down           # ローカルMongoDB停止
 bash scripts/use-atlas.sh     # Atlas設定に切り替え
 go run cmd/api/main.go        # 再起動
 
 # Atlas → ローカル
 # （APIサーバーを停止）
 bash scripts/use-local.sh     # ローカル設定に切り替え
-docker-compose up -d          # ローカルMongoDB起動
+docker compose up -d          # ローカルMongoDB起動
 go run cmd/api/main.go        # 再起動
 ```
 
 ---
 
-## 🐛 トラブルシューティング
+## トラブルシューティング
 
-### 問題1: `docker-compose up -d`が失敗する
+### 問題1: `docker compose up -d`が失敗する
 **原因**: Dockerが起動していない
 **解決策**:
 ```bash
 # Docker Desktopを起動してから再実行
-docker-compose up -d
+docker compose up -d
 ```
 
 ### 問題2: MongoDBに接続できない（ローカル）
@@ -172,10 +184,10 @@ docker-compose up -d
 **解決策**:
 ```bash
 # コンテナの状態確認
-docker-compose ps
+docker compose ps
 
 # 再起動
-docker-compose restart mongodb
+docker compose restart mongodb
 ```
 
 ### 問題3: MongoDBに接続できない（Atlas）
@@ -201,23 +213,23 @@ kill -9 <PID>
 ```
 
 ### 問題5: データが消えた
-**原因**: `docker-compose down -v`でボリュームを削除した
+**原因**: `docker compose down -v`でボリュームを削除した
 **解決策**:
 - **ローカル**: データはボリュームに保存されるため、`-v`オプションなしで停止すること
 - **Atlas**: クラウドなので心配不要
 
 ---
 
-## ⚙️ Docker Composeコマンド早見表
+## Docker Composeコマンド早見表
 
 | コマンド | 説明 |
 |---------|------|
-| `docker-compose up -d` | バックグラウンドで起動 |
-| `docker-compose ps` | コンテナの状態確認 |
-| `docker-compose logs mongodb` | MongoDBのログ確認 |
-| `docker-compose restart mongodb` | MongoDB再起動 |
-| `docker-compose down` | コンテナ停止（データは保持） |
-| `docker-compose down -v` | コンテナ停止 + データ削除 ⚠️ |
+| `docker compose up -d` | バックグラウンドで起動 |
+| `docker compose ps` | コンテナの状態確認 |
+| `docker compose logs mongodb` | MongoDBのログ確認 |
+| `docker compose restart mongodb` | MongoDB再起動 |
+| `docker compose down` | コンテナ停止（データは保持） |
+| `docker compose down -v` | コンテナ停止 + データ削除 ⚠️ |
 
 ---
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -736,7 +736,7 @@ const docTemplate = `{
         },
         "/idols/bulk": {
             "post": {
-                "description": "複数のアイドルを一括作成する（write認証必須、最大500件）",
+                "description": "複数のアイドルを一括作成する（write認証必須、最大100件）",
                 "consumes": [
                     "application/json"
                 ],
@@ -1574,7 +1574,7 @@ const docTemplate = `{
             "properties": {
                 "idols": {
                     "type": "array",
-                    "maxItems": 500,
+                    "maxItems": 100,
                     "minItems": 1,
                     "items": {
                         "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -734,7 +734,7 @@
         },
         "/idols/bulk": {
             "post": {
-                "description": "複数のアイドルを一括作成する（write認証必須、最大500件）",
+                "description": "複数のアイドルを一括作成する（write認証必須、最大100件）",
                 "consumes": [
                     "application/json"
                 ],
@@ -1572,7 +1572,7 @@
             "properties": {
                 "idols": {
                     "type": "array",
-                    "maxItems": 500,
+                    "maxItems": 100,
                     "minItems": 1,
                     "items": {
                         "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -119,7 +119,7 @@ definitions:
           required:
           - name
           type: object
-        maxItems: 500
+        maxItems: 100
         minItems: 1
         type: array
     required:
@@ -1212,7 +1212,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: 複数のアイドルを一括作成する（write認証必須、最大500件）
+      description: 複数のアイドルを一括作成する（write認証必須、最大100件）
       parameters:
       - description: バルク作成リクエスト
         in: body

--- a/internal/application/export/service.go
+++ b/internal/application/export/service.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"time"
 
 	appIdol "github.com/kuro48/idol-api/internal/application/idol"
@@ -51,14 +52,16 @@ func (s *ApplicationService) ExportIdols(ctx context.Context, format domainExpor
 	idols, err := s.idolApp.ListIdols(ctx)
 	if err != nil {
 		exportLog.MarkFailed(err.Error())
-		_ = s.logRepo.Save(ctx, exportLog)
+		if saveErr := s.logRepo.Save(ctx, exportLog); saveErr != nil {
+			slog.Warn("エクスポート失敗ログの保存に失敗しました", "error", saveErr)
+		}
 		return nil, fmt.Errorf("アイドルデータ取得エラー: %w", err)
 	}
 
 	exportLog.SetRecordCount(len(idols))
 	if err := s.logRepo.Save(ctx, exportLog); err != nil {
 		// ログ保存失敗でもエクスポート自体は続行
-		_ = err
+		slog.Warn("エクスポートログの保存に失敗しました", "error", err)
 	}
 
 	return &domainExport.ExportIdolsResult{
@@ -78,6 +81,8 @@ func (s *ApplicationService) ListExportLogs(ctx context.Context, limit int) ([]*
 
 func generateExportID() string {
 	b := make([]byte, 12)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("crypto/rand.Read failed: %v", err))
+	}
 	return hex.EncodeToString(b)
 }

--- a/internal/domain/tag/value_object.go
+++ b/internal/domain/tag/value_object.go
@@ -32,7 +32,9 @@ func NewTagID(value string) (TagID, error) {
 // GenerateTagID は新しいIDを生成する（12バイトランダム = 24文字16進数）
 func GenerateTagID() TagID {
 	var b [12]byte
-	_, _ = rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("crypto/rand.Read failed: " + err.Error())
+	}
 	return TagID{value: hex.EncodeToString(b[:])}
 }
 

--- a/internal/domain/webhook/webhook.go
+++ b/internal/domain/webhook/webhook.go
@@ -17,6 +17,18 @@ const (
 	EventRemovalApproved EventType = "removal.approved"
 )
 
+// IsValidEventType はEventTypeが定義済みの有効な値かを判定する
+func IsValidEventType(e EventType) bool {
+	switch e {
+	case EventIdolCreated, EventIdolUpdated, EventIdolDeleted,
+		EventGroupCreated, EventGroupUpdated, EventGroupDeleted,
+		EventRemovalApproved:
+		return true
+	default:
+		return false
+	}
+}
+
 // DeliveryStatus はWebhook配信状態
 type DeliveryStatus string
 

--- a/internal/interface/handlers/export_handler.go
+++ b/internal/interface/handlers/export_handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -220,5 +221,5 @@ func isRateLimitError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return len(err.Error()) > 8 && err.Error()[:8] == "レート制限"
+	return strings.HasPrefix(err.Error(), "レート制限")
 }

--- a/internal/interface/handlers/idol_handler.go
+++ b/internal/interface/handlers/idol_handler.go
@@ -313,12 +313,12 @@ type BulkCreateIdolsRequest struct {
 		Name      string  `json:"name" binding:"required,min=1,max=100"`
 		Birthdate *string `json:"birthdate"`
 		AgencyID  *string `json:"agency_id"`
-	} `json:"idols" binding:"required,min=1,max=500"`
+	} `json:"idols" binding:"required,min=1,max=100"`
 }
 
-// BulkCreateIdols はアイドルを一括作成する（最大500件）
+// BulkCreateIdols はアイドルを一括作成する（最大100件）
 // @Summary      アイドル一括作成
-// @Description  複数のアイドルを一括作成する（write認証必須、最大500件）
+// @Description  複数のアイドルを一括作成する（write認証必須、最大100件）
 // @Tags         idols
 // @Accept       json
 // @Produce      json

--- a/internal/interface/handlers/webhook_handler.go
+++ b/internal/interface/handlers/webhook_handler.go
@@ -65,7 +65,12 @@ func (h *WebhookHandler) CreateSubscription(c *gin.Context) {
 
 	events := make([]webhook.EventType, len(req.Events))
 	for i, e := range req.Events {
-		events[i] = webhook.EventType(e)
+		et := webhook.EventType(e)
+		if !webhook.IsValidEventType(et) {
+			c.JSON(http.StatusBadRequest, middleware.NewBadRequestError("不正なイベントタイプです: "+e))
+			return
+		}
+		events[i] = et
 	}
 
 	sub, err := h.appService.CreateSubscription(middleware.AuditContextFor(c), req.URL, events, middleware.GetActor(c))


### PR DESCRIPTION
## 概要
リリース前に残っていたドキュメント・API 契約・OpenAPI 生成物の不整合を解消しました。

## 変更内容
- README の認証方式と API 一覧を実装に合わせて修正
- deployment / docker guide を現在のリリース運用に合わせて更新
- Webhook イベント種別の入力バリデーションを追加
- バルク作成上限の注釈と OpenAPI 生成物を同期
- エラーログとランダム ID 生成周辺の小さな堅牢化を反映

## テスト
- `go test ./...`
- `go vet ./...`
- `go build ./cmd/api`

Closes #106
Closes #107
Closes #108
Closes #109